### PR TITLE
change gensym to cl-gensym

### DIFF
--- a/ctable.el
+++ b/ctable.el
@@ -310,7 +310,7 @@ select-ol   : a list of overlays for selection"
 (eval-when-compile
   (defmacro ctbl:dest-with-region (dest &rest body)
     (declare (debug (form &rest form)))
-    (let (($dest (gensym)))
+    (let (($dest (cl-gensym)))
       `(let ((,$dest ,dest))
          (with-current-buffer (ctbl:dest-buffer ,$dest)
            (save-restriction


### PR DESCRIPTION
I encountered emacs-ctable as in indirect dependency of emacs-jedi, and it was causing an error message:
```
Eager macro-expansion failure: (void-function gensym)
```
This error can be reproduced with
```
M-x package-install RET ctable RET
(require 'ctable)
```
(I got ctable-20210128.629)
Patching .emacs.d/elpa/ctable-20210128.629/ctable.el as in this PR made `(require 'ctable)` work without error.